### PR TITLE
Get current login user by $USER and Fixed config path if current login user is root.

### DIFF
--- a/fdir.sh
+++ b/fdir.sh
@@ -15,11 +15,8 @@
 
 VERSION="1.0"
 
-#Get Logined User
-CURRENTUSER=$(who | cut -d' ' -f1)
-
 #Variable
-CONFIG_FILE="/home/$CURRENTUSER/.fdirrc"
+CONFIG_FILE="/home/$USER/.fdirrc"
 
 #==================== METHOD =======================#
 ShowError() 
@@ -102,6 +99,7 @@ Help()
 if [ ! -f $CONFIG_FILE ]; then
     touch $CONFIG_FILE
 fi
+
 if [ "$1" == "-s" ]; then
     Save $2
 elif [ "$1" == "-r" ]; then

--- a/fdir.sh
+++ b/fdir.sh
@@ -16,7 +16,13 @@
 VERSION="1.0"
 
 #Variable
-CONFIG_FILE="/home/$USER/.fdirrc"
+CURRENTUSER=$USER
+
+if [ "$CURRENTUSER" == "root" ]; then
+    CONFIG_FILE="/$CURRENTUSER/.fdirrc"
+else
+    CONFIG_FILE="/home/$CURRENTUSER/.fdirrc"
+fi
 
 #==================== METHOD =======================#
 ShowError() 


### PR DESCRIPTION
$USER will get login user no matter you 'su' or 'sudo'
ex -> login user "A"
sudo echo $USER -> A
su -> echo $USER -> A
---------------------------
If current login user is "root' -> dir "/home/root/" is not exist.
So, change to -> dir "/root/".
This prevent error in create new config via "touch"

