### PR TITLE
Feature delete unexist dir

### DIFF
--- a/fdir.sh
+++ b/fdir.sh
@@ -176,9 +176,10 @@ RemoveGarbageKey()
         fi
     done
 
-    echo "Backup an old file..."
     cp $CONFIG_FILE "${CONFIG_FILE}_backup"
     mv ${CONFIG_FILE}_temp $CONFIG_FILE
+
+    echo "Backup of an old file has been saved to : ${CONFIG_FILE}_backup"
 }
 
 #==================== MAIN =======================#

--- a/fdir.sh
+++ b/fdir.sh
@@ -150,6 +150,36 @@ Help()
     echo -e "\t\t$ fd-mydir"
 }
 
+RemoveGarbageKeyPrompt()
+{
+    echo -n "Delete the keys that point to an un-exist directory? (y/n) : "
+    read RESULT
+    case $RESULT in
+        [yY]* ) RemoveGarbageKey;;
+        [nN]* ) exit;;
+    esac
+}
+
+RemoveGarbageKey()
+{
+    echo "Check if key points to exist directory..."
+    cp /dev/null .fdir_temp
+
+    cat $CONFIG_FILE | while read -r line ; do
+        DIR=$(echo $line | grep -o "/.*[^\"]")
+        KEY=$(echo $line | grep -o "fd-[[:alnum:]]*")
+
+        if [ -d $DIR ]; then
+            echo $line >> .fdir_temp
+        else
+            echo "Remove key : $KEY"
+        fi
+    done
+
+    echo "Backup an old file..."
+    cp $CONFIG_FILE "${CONFIG_FILE}_old"
+    mv .fdir_temp $CONFIG_FILE
+}
 
 #==================== MAIN =======================#
 
@@ -166,6 +196,8 @@ elif [ "$1" == "-v" ]; then
     echo ""
 elif [ "$1" == "init" ]; then
     Init
+elif [ "$1" == "--clean" ]; then
+    RemoveGarbageKeyPrompt
 else
     ShowError
 fi

--- a/fdir.sh
+++ b/fdir.sh
@@ -163,22 +163,22 @@ RemoveGarbageKeyPrompt()
 RemoveGarbageKey()
 {
     echo "Check if key points to exist directory..."
-    cp /dev/null .fdir_temp
+    cp /dev/null ${CONFIG_FILE}_temp
 
     cat $CONFIG_FILE | while read -r line ; do
         DIR=$(echo $line | grep -o "/.*[^\"]")
-        KEY=$(echo $line | grep -o "fd-[[:alnum:]]*")
+        KEY=$(echo $line | grep -o "$PREFIX_[[:alnum:]]*")
 
         if [ -d $DIR ]; then
-            echo $line >> .fdir_temp
+            echo $line >> ${CONFIG_FILE}_temp
         else
             echo "Remove key : $KEY"
         fi
     done
 
     echo "Backup an old file..."
-    cp $CONFIG_FILE "${CONFIG_FILE}_old"
-    mv .fdir_temp $CONFIG_FILE
+    cp $CONFIG_FILE "${CONFIG_FILE}_backup"
+    mv ${CONFIG_FILE}_temp $CONFIG_FILE
 }
 
 #==================== MAIN =======================#

--- a/fdir.sh
+++ b/fdir.sh
@@ -140,6 +140,7 @@ Help()
     echo -e "\t-s <key> \tLink <key> to current directory"
     echo -e "\t-r <key> \tRemove <key>"
     echo -e "\t-l \t\tList all <key>"
+    echo -e "\t--clean \tDelete all key that points to un-exist directory <key>"
     echo -e "\t-v \t\tShow version"
     echo ""
     echo -e "[EXAMPLE]"


### PR DESCRIPTION
- Delete keys that point to an unexist directory (garbage key) in config file.
- Usage : fd --clean
- Useful when you forget to remove the keys that its dir already removed.
- (Use this as an example file : https://gist.github.com/CSaratakij/0f4bcfab60d78bcdb3113740843f559a)